### PR TITLE
Add copy command

### DIFF
--- a/src/main/java/seedu/address/logic/commands/CopyCommand.java
+++ b/src/main/java/seedu/address/logic/commands/CopyCommand.java
@@ -1,18 +1,16 @@
 package seedu.address.logic.commands;
 
+import static java.util.Objects.requireNonNull;
+
+import java.util.List;
+
 import javafx.scene.input.Clipboard;
 import javafx.scene.input.ClipboardContent;
 import seedu.address.logic.commands.descriptors.CopyCommandDescriptor;
 import seedu.address.model.Model;
 import seedu.address.model.person.Person;
 
-import java.util.List;
-
-import static java.util.Objects.requireNonNull;
-
 public class CopyCommand extends Command {
-
-    CopyCommandDescriptor copyCommandDescriptor;
 
     public static final String COMMAND_WORD = "copy";
     public static final String MESSAGE_SUCCESS = "Fields have been copied to clipboard!";
@@ -21,11 +19,23 @@ public class CopyCommand extends Command {
     public static final String NO_FIELD_PROVIDED = "At least one field to copy must be provided. Use the c/ prefix.";
     public static final String MESSAGE_USAGE = "Just get good lol";
 
+    private CopyCommandDescriptor copyCommandDescriptor;
+
+    /**
+     * Constructor for {@code Copycommand}
+     *
+     * @param copyCommandDescriptor the {@copyCommandDescriptor to specify which field to copy}
+     */
+
     public CopyCommand(CopyCommandDescriptor copyCommandDescriptor) {
         this.copyCommandDescriptor = copyCommandDescriptor;
     }
 
-
+    /**
+     * Copies attributes of the {@code personList} to the clipboard
+     *
+     * @param personList the person list to copy from
+     */
     public void copyToClipBoard(List<Person> personList) {
         final Clipboard clipboard = Clipboard.getSystemClipboard();
         final ClipboardContent url = new ClipboardContent();
@@ -33,6 +43,12 @@ public class CopyCommand extends Command {
         clipboard.setContent(url);
     }
 
+    /**
+     * Get the string representation of the content to copy from
+     *
+     * @param personList the person list to copy from
+     * @return the string representation
+     */
     public String getCopyContent(List<Person> personList) {
         // TODO: convert to switch statement soon
         if (copyCommandDescriptor.getField().equals(CopyCommandDescriptor.Field.PHONE)) {
@@ -48,6 +64,12 @@ public class CopyCommand extends Command {
         return "";
     }
 
+    /**
+     * Get the string representation of the phone content to copy from
+     *
+     * @param personList the person list to copy from
+     * @return the string representation
+     */
     public String getPhoneContent(List<Person> personList) {
         StringBuilder sb = new StringBuilder();
         for (int i = 0; i < personList.size(); i++) {
@@ -62,6 +84,12 @@ public class CopyCommand extends Command {
         return sb.toString();
     }
 
+    /**
+     * Get the string representation of the email content to copy from
+     *
+     * @param personList the person list to copy from
+     * @return the string representation
+     */
     public String getEmailContent(List<Person> personList) {
         StringBuilder sb = new StringBuilder();
         for (int i = 0; i < personList.size(); i++) {
@@ -75,6 +103,12 @@ public class CopyCommand extends Command {
         return sb.toString();
     }
 
+    /**
+     * Get the string representation of the name content to copy from
+     *
+     * @param personList the person list to copy from
+     * @return the string representation
+     */
     public String getNameContent(List<Person> personList) {
         StringBuilder sb = new StringBuilder();
         for (int i = 0; i < personList.size(); i++) {

--- a/src/main/java/seedu/address/logic/commands/CopyCommand.java
+++ b/src/main/java/seedu/address/logic/commands/CopyCommand.java
@@ -3,7 +3,6 @@ package seedu.address.logic.commands;
 import javafx.scene.input.Clipboard;
 import javafx.scene.input.ClipboardContent;
 import seedu.address.logic.commands.descriptors.CopyCommandDescriptor;
-import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
 import seedu.address.model.person.Person;
 
@@ -19,7 +18,7 @@ public class CopyCommand extends Command {
     public static final String MESSAGE_SUCCESS = "Fields have been copied to clipboard!";
     public static final String MESSAGE_NOT_VALID_FIELD = "Field specified is not a valid field! Only the 'phone' "
             + "field is supported.";
-    public static final String MESSAGE_NOT_COPIED = "At least one field to copy must be provided.";
+    public static final String MESSAGE_NOT_COPIED = "At least one field to copy must be provided. Use the c/ prefix.";
     public static final String MESSAGE_USAGE = "Just get good lol";
 
     public CopyCommand(CopyCommandDescriptor copyCommandDescriptor) {
@@ -44,8 +43,12 @@ public class CopyCommand extends Command {
 
     public String getPhoneContent(List<Person> personList) {
         StringBuilder sb = new StringBuilder();
-        for (Person person: personList) {
-            sb.append(person.getPhone() + ",");
+        for (int i = 0; i < personList.size(); i++) {
+            if (i == personList.size() - 1) {
+                sb.append(personList.get(i).getPhone());
+            } else {
+                sb.append(personList.get(i).getPhone() + " ");
+            }
         }
         return sb.toString();
     }

--- a/src/main/java/seedu/address/logic/commands/CopyCommand.java
+++ b/src/main/java/seedu/address/logic/commands/CopyCommand.java
@@ -1,0 +1,67 @@
+package seedu.address.logic.commands;
+
+import javafx.scene.input.Clipboard;
+import javafx.scene.input.ClipboardContent;
+import seedu.address.logic.commands.descriptors.CopyCommandDescriptor;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.model.person.Person;
+
+import java.util.List;
+
+import static java.util.Objects.requireNonNull;
+
+public class CopyCommand extends Command {
+
+    CopyCommandDescriptor copyCommandDescriptor;
+
+    public static final String COMMAND_WORD = "copy";
+    public static final String MESSAGE_SUCCESS = "Fields have been copied to clipboard!";
+    public static final String MESSAGE_NOT_VALID_FIELD = "Field specified is not a valid field! Only the 'phone' "
+            + "field is supported.";
+    public static final String MESSAGE_NOT_COPIED = "At least one field to copy must be provided.";
+    public static final String MESSAGE_USAGE = "Just get good lol";
+
+    public CopyCommand(CopyCommandDescriptor copyCommandDescriptor) {
+        this.copyCommandDescriptor = copyCommandDescriptor;
+    }
+
+
+    public void copyToClipBoard(List<Person> personList) {
+        final Clipboard clipboard = Clipboard.getSystemClipboard();
+        final ClipboardContent url = new ClipboardContent();
+        url.putString(getCopyContent(personList));
+        clipboard.setContent(url);
+    }
+
+    public String getCopyContent(List<Person> personList) {
+        if (copyCommandDescriptor.getField().equals(CopyCommandDescriptor.Field.PHONE)) {
+            return getPhoneContent(personList);
+        }
+        // should not reach here
+        return "";
+    }
+
+    public String getPhoneContent(List<Person> personList) {
+        StringBuilder sb = new StringBuilder();
+        for (Person person: personList) {
+            sb.append(person.getPhone() + ",");
+        }
+        return sb.toString();
+    }
+
+    @Override
+    public CommandResult execute(Model model) {
+        requireNonNull(model);
+        List<Person> lastShownList = model.getFilteredPersonList();
+        copyToClipBoard(lastShownList);
+        return new CommandResult(MESSAGE_SUCCESS);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof CopyCommand // instanceof handles nulls
+                && copyCommandDescriptor.equals(((CopyCommand) other).copyCommandDescriptor)); // state check
+    }
+}

--- a/src/main/java/seedu/address/logic/commands/CopyCommand.java
+++ b/src/main/java/seedu/address/logic/commands/CopyCommand.java
@@ -34,8 +34,15 @@ public class CopyCommand extends Command {
     }
 
     public String getCopyContent(List<Person> personList) {
+        // TODO: convert to switch statement soon
         if (copyCommandDescriptor.getField().equals(CopyCommandDescriptor.Field.PHONE)) {
             return getPhoneContent(personList);
+        }
+        if (copyCommandDescriptor.getField().equals(CopyCommandDescriptor.Field.EMAIL)) {
+            return getEmailContent(personList);
+        }
+        if (copyCommandDescriptor.getField().equals(CopyCommandDescriptor.Field.NAME)) {
+            return getNameContent(personList);
         }
         // should not reach here, invalid fields should have been filtered out while parsing
         return "";
@@ -47,7 +54,36 @@ public class CopyCommand extends Command {
             if (i == personList.size() - 1) {
                 sb.append(personList.get(i).getPhone());
             } else {
+                // for phones, we put commas in case the user wants to paste it directly into whatsapp or some other
+                // phone directory
                 sb.append(personList.get(i).getPhone() + " ");
+            }
+        }
+        return sb.toString();
+    }
+
+    public String getEmailContent(List<Person> personList) {
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < personList.size(); i++) {
+            if (i == personList.size() - 1) {
+                sb.append(personList.get(i).getEmail());
+            } else {
+                // for emails, we put commas in case the user wants to paste it directly into gmail
+                sb.append(personList.get(i).getEmail() + ",");
+            }
+        }
+        return sb.toString();
+    }
+
+    public String getNameContent(List<Person> personList) {
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < personList.size(); i++) {
+            if (i == personList.size() - 1) {
+                sb.append(personList.get(i).getName());
+            } else {
+                // for names, we put commas, else the spacing between the first and last names might be confused with
+                // another name
+                sb.append(personList.get(i).getName() + ", ");
             }
         }
         return sb.toString();

--- a/src/main/java/seedu/address/logic/commands/CopyCommand.java
+++ b/src/main/java/seedu/address/logic/commands/CopyCommand.java
@@ -18,7 +18,7 @@ public class CopyCommand extends Command {
     public static final String MESSAGE_SUCCESS = "Fields have been copied to clipboard!";
     public static final String MESSAGE_NOT_VALID_FIELD = "Field specified is not a valid field! Only the 'phone' "
             + "field is supported.";
-    public static final String MESSAGE_NOT_COPIED = "At least one field to copy must be provided. Use the c/ prefix.";
+    public static final String NO_FIELD_PROVIDED = "At least one field to copy must be provided. Use the c/ prefix.";
     public static final String MESSAGE_USAGE = "Just get good lol";
 
     public CopyCommand(CopyCommandDescriptor copyCommandDescriptor) {
@@ -37,7 +37,7 @@ public class CopyCommand extends Command {
         if (copyCommandDescriptor.getField().equals(CopyCommandDescriptor.Field.PHONE)) {
             return getPhoneContent(personList);
         }
-        // should not reach here
+        // should not reach here, invalid fields should have been filtered out while parsing
         return "";
     }
 

--- a/src/main/java/seedu/address/logic/commands/EditStudentCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditStudentCommand.java
@@ -44,6 +44,7 @@ public class EditStudentCommand extends EditCommand {
             + "Example: " + COMMAND_WORD + " 1 "
             + PREFIX_PHONE + "91234567 "
             + PREFIX_EMAIL + "johndoe@example.com";
+
     public final EditStudentDescriptor editStudentDescriptor;
     private final Index index;
 

--- a/src/main/java/seedu/address/logic/commands/descriptors/CopyCommandDescriptor.java
+++ b/src/main/java/seedu/address/logic/commands/descriptors/CopyCommandDescriptor.java
@@ -8,7 +8,7 @@ public class CopyCommandDescriptor {
 
     public enum Field {
 
-        PHONE("phone"), EMAIL("email"), INVALID("invalid");
+        PHONE("phone"), EMAIL("email"), NAME("name"), INVALID("invalid");
 
         private String field;
 
@@ -25,12 +25,14 @@ public class CopyCommandDescriptor {
     private Field fieldToCopy;
 
     public CopyCommandDescriptor(String fieldToCopy) {
-        // change to switch statement soon
+        // TODO: change to switch statement soon
         requireNonNull(fieldToCopy);
         if (fieldToCopy.equals("phone")) {
             this.fieldToCopy = Field.PHONE;
         } else if (fieldToCopy.equals("email")) {
             this.fieldToCopy = Field.EMAIL;
+        } else if (fieldToCopy.equals("name")) {
+            this.fieldToCopy = Field.NAME;
         }
         else {
             this.fieldToCopy = Field.INVALID;

--- a/src/main/java/seedu/address/logic/commands/descriptors/CopyCommandDescriptor.java
+++ b/src/main/java/seedu/address/logic/commands/descriptors/CopyCommandDescriptor.java
@@ -1,8 +1,6 @@
 package seedu.address.logic.commands.descriptors;
 
-import seedu.address.logic.commands.CopyCommand;
 
-import static seedu.address.commons.util.AppUtil.checkArgument;
 import static java.util.Objects.requireNonNull;
 
 
@@ -28,11 +26,9 @@ public class CopyCommandDescriptor {
 
     public CopyCommandDescriptor(String fieldToCopy) {
         requireNonNull(fieldToCopy);
-        checkArgument(isValidField(fieldToCopy), CopyCommand.MESSAGE_NOT_VALID_FIELD);
         if (fieldToCopy.equals("phone")) {
             this.fieldToCopy = Field.PHONE;
         }
-
     }
 
     public static boolean isValidField(String fieldToCopy) {

--- a/src/main/java/seedu/address/logic/commands/descriptors/CopyCommandDescriptor.java
+++ b/src/main/java/seedu/address/logic/commands/descriptors/CopyCommandDescriptor.java
@@ -8,7 +8,7 @@ public class CopyCommandDescriptor {
 
     public enum Field {
 
-        PHONE("phone");
+        PHONE("phone"), EMAIL("email"), INVALID("invalid");
 
         private String field;
 
@@ -25,14 +25,20 @@ public class CopyCommandDescriptor {
     private Field fieldToCopy;
 
     public CopyCommandDescriptor(String fieldToCopy) {
+        // change to switch statement soon
         requireNonNull(fieldToCopy);
         if (fieldToCopy.equals("phone")) {
             this.fieldToCopy = Field.PHONE;
+        } else if (fieldToCopy.equals("email")) {
+            this.fieldToCopy = Field.EMAIL;
+        }
+        else {
+            this.fieldToCopy = Field.INVALID;
         }
     }
 
-    public static boolean isValidField(String fieldToCopy) {
-        return fieldToCopy.equals("phone");
+    public boolean hasValidField() {
+        return !fieldToCopy.equals(Field.INVALID);
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/descriptors/CopyCommandDescriptor.java
+++ b/src/main/java/seedu/address/logic/commands/descriptors/CopyCommandDescriptor.java
@@ -1,0 +1,62 @@
+package seedu.address.logic.commands.descriptors;
+
+import seedu.address.logic.commands.CopyCommand;
+
+import static seedu.address.commons.util.AppUtil.checkArgument;
+import static java.util.Objects.requireNonNull;
+
+
+public class CopyCommandDescriptor {
+
+    public enum Field {
+
+        PHONE("phone");
+
+        private String field;
+
+        Field(String field) {
+            this.field = field;
+        }
+
+        @Override
+        public String toString() {
+            return field;
+        }
+    }
+
+    private Field fieldToCopy;
+
+    public CopyCommandDescriptor(String fieldToCopy) {
+        requireNonNull(fieldToCopy);
+        checkArgument(isValidField(fieldToCopy), CopyCommand.MESSAGE_NOT_VALID_FIELD);
+        if (fieldToCopy.equals("phone")) {
+            this.fieldToCopy = Field.PHONE;
+        }
+
+    }
+
+    public static boolean isValidField(String fieldToCopy) {
+        return fieldToCopy.equals("phone");
+    }
+
+    @Override
+    public String toString() {
+        return fieldToCopy.toString();
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof CopyCommandDescriptor // instanceof handles nulls
+                && fieldToCopy.equals(((CopyCommandDescriptor) other).fieldToCopy)); // state check
+    }
+
+    public Field getField() {
+        return this.fieldToCopy;
+    }
+
+    @Override
+    public int hashCode() {
+        return fieldToCopy.hashCode();
+    }
+}

--- a/src/main/java/seedu/address/logic/commands/descriptors/CopyCommandDescriptor.java
+++ b/src/main/java/seedu/address/logic/commands/descriptors/CopyCommandDescriptor.java
@@ -3,7 +3,9 @@ package seedu.address.logic.commands.descriptors;
 
 import static java.util.Objects.requireNonNull;
 
-
+/**
+ * This class stores information about which field to be copied based on the string given to it.
+ */
 public class CopyCommandDescriptor {
 
     public enum Field {
@@ -24,6 +26,11 @@ public class CopyCommandDescriptor {
 
     private Field fieldToCopy;
 
+    /**
+     * Constructor of the {@code CopyCommandDescriptor}
+     *
+     * @param fieldToCopy A string to represent which field to copy
+     */
     public CopyCommandDescriptor(String fieldToCopy) {
         // TODO: change to switch statement soon
         requireNonNull(fieldToCopy);
@@ -33,8 +40,7 @@ public class CopyCommandDescriptor {
             this.fieldToCopy = Field.EMAIL;
         } else if (fieldToCopy.equals("name")) {
             this.fieldToCopy = Field.NAME;
-        }
-        else {
+        } else {
             this.fieldToCopy = Field.INVALID;
         }
     }

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -8,6 +8,7 @@ import java.util.regex.Pattern;
 
 import seedu.address.logic.commands.ClearCommand;
 import seedu.address.logic.commands.Command;
+import seedu.address.logic.commands.CopyCommand;
 import seedu.address.logic.commands.DeleteCommand;
 import seedu.address.logic.commands.EditStudentCommand;
 import seedu.address.logic.commands.ExitCommand;
@@ -61,6 +62,9 @@ public class AddressBookParser {
 
         case ListCommand.COMMAND_WORD:
             return new ListCommand();
+
+        case CopyCommand.COMMAND_WORD:
+            return new CopyCommandParser().parse(arguments);
 
         case ExitCommand.COMMAND_WORD:
             return new ExitCommand();

--- a/src/main/java/seedu/address/logic/parser/CliSyntax.java
+++ b/src/main/java/seedu/address/logic/parser/CliSyntax.java
@@ -15,4 +15,5 @@ public class CliSyntax {
     public static final Prefix PREFIX_INVOLVEMENT = new Prefix("i/");
     public static final Prefix PREFIX_FORM_CLASS = new Prefix("f/");
     public static final Prefix PREFIX_GENDER = new Prefix("g/");
+    public static final Prefix PREFIX_COPY_FIELD = new Prefix("c/");
 }

--- a/src/main/java/seedu/address/logic/parser/CopyCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/CopyCommandParser.java
@@ -1,0 +1,31 @@
+package seedu.address.logic.parser;
+
+import seedu.address.logic.commands.CopyCommand;
+import seedu.address.logic.commands.descriptors.CopyCommandDescriptor;
+
+import seedu.address.logic.parser.exceptions.ParseException;
+
+import java.util.Optional;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_COPY_FIELD;
+
+public class CopyCommandParser implements Parser<CopyCommand> {
+
+    /**
+     * Parses the given {@code String} of arguments in the context of the CopyCommand
+     * and returns a CopyCommand object for execution.
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public CopyCommand parse(String args) throws ParseException {
+        requireNonNull(args);
+        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_COPY_FIELD);
+        Optional<String> fieldToCopy = argMultimap.getValue(PREFIX_COPY_FIELD);
+        if (!fieldToCopy.isPresent()) {
+            throw new ParseException(CopyCommand.MESSAGE_NOT_COPIED);
+        } else {
+            CopyCommandDescriptor copyCommandDescriptor = new CopyCommandDescriptor(fieldToCopy.get());
+            return new CopyCommand(copyCommandDescriptor);
+        }
+    }
+}

--- a/src/main/java/seedu/address/logic/parser/CopyCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/CopyCommandParser.java
@@ -22,10 +22,14 @@ public class CopyCommandParser implements Parser<CopyCommand> {
         ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_COPY_FIELD);
         Optional<String> fieldToCopy = argMultimap.getValue(PREFIX_COPY_FIELD);
         if (!fieldToCopy.isPresent()) {
-            throw new ParseException(CopyCommand.MESSAGE_NOT_COPIED);
+            throw new ParseException(CopyCommand.MESSAGE_NOT_COPIED + "\n" + CopyCommand.MESSAGE_USAGE);
         } else {
-            CopyCommandDescriptor copyCommandDescriptor = new CopyCommandDescriptor(fieldToCopy.get());
-            return new CopyCommand(copyCommandDescriptor);
+            if (CopyCommandDescriptor.isValidField(fieldToCopy.get())) {
+                CopyCommandDescriptor copyCommandDescriptor = new CopyCommandDescriptor(fieldToCopy.get());
+                return new CopyCommand(copyCommandDescriptor);
+            } else {
+                throw new ParseException(CopyCommand.MESSAGE_NOT_VALID_FIELD);
+            }
         }
     }
 }

--- a/src/main/java/seedu/address/logic/parser/CopyCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/CopyCommandParser.java
@@ -1,14 +1,15 @@
 package seedu.address.logic.parser;
 
-import seedu.address.logic.commands.CopyCommand;
-import seedu.address.logic.commands.descriptors.CopyCommandDescriptor;
-
-import seedu.address.logic.parser.exceptions.ParseException;
+import static java.util.Objects.requireNonNull;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_COPY_FIELD;
 
 import java.util.Optional;
 
-import static java.util.Objects.requireNonNull;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_COPY_FIELD;
+import seedu.address.logic.commands.CopyCommand;
+import seedu.address.logic.commands.descriptors.CopyCommandDescriptor;
+import seedu.address.logic.parser.exceptions.ParseException;
+
+
 
 public class CopyCommandParser implements Parser<CopyCommand> {
 

--- a/src/main/java/seedu/address/logic/parser/CopyCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/CopyCommandParser.java
@@ -22,10 +22,10 @@ public class CopyCommandParser implements Parser<CopyCommand> {
         ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_COPY_FIELD);
         Optional<String> fieldToCopy = argMultimap.getValue(PREFIX_COPY_FIELD);
         if (!fieldToCopy.isPresent()) {
-            throw new ParseException(CopyCommand.MESSAGE_NOT_COPIED + "\n" + CopyCommand.MESSAGE_USAGE);
+            throw new ParseException(CopyCommand.NO_FIELD_PROVIDED + "\n" + CopyCommand.MESSAGE_USAGE);
         } else {
-            if (CopyCommandDescriptor.isValidField(fieldToCopy.get())) {
-                CopyCommandDescriptor copyCommandDescriptor = new CopyCommandDescriptor(fieldToCopy.get());
+            CopyCommandDescriptor copyCommandDescriptor = new CopyCommandDescriptor(fieldToCopy.get());
+            if (copyCommandDescriptor.hasValidField()) {
                 return new CopyCommand(copyCommandDescriptor);
             } else {
                 throw new ParseException(CopyCommand.MESSAGE_NOT_VALID_FIELD);

--- a/src/test/java/seedu/address/logic/commands/CopyCommandDescriptorTest.java
+++ b/src/test/java/seedu/address/logic/commands/CopyCommandDescriptorTest.java
@@ -1,11 +1,12 @@
 package seedu.address.logic.commands;
 
-import org.junit.jupiter.api.Test;
-import seedu.address.logic.commands.descriptors.CopyCommandDescriptor;
-
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.logic.commands.descriptors.CopyCommandDescriptor;
 
 public class CopyCommandDescriptorTest {
 

--- a/src/test/java/seedu/address/logic/commands/CopyCommandDescriptorTest.java
+++ b/src/test/java/seedu/address/logic/commands/CopyCommandDescriptorTest.java
@@ -1,0 +1,35 @@
+package seedu.address.logic.commands;
+
+import org.junit.jupiter.api.Test;
+import seedu.address.logic.commands.descriptors.CopyCommandDescriptor;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+public class CopyCommandDescriptorTest {
+
+    @Test
+    public void equals() {
+        // same values -> returns true
+        CopyCommandDescriptor phoneDescriptor = new CopyCommandDescriptor("phone");
+        CopyCommandDescriptor emailDescriptor = new CopyCommandDescriptor("email");
+        CopyCommandDescriptor invalidDescriptor = new CopyCommandDescriptor("fish");
+        CopyCommandDescriptor anotherPhone = new CopyCommandDescriptor("phone");
+
+        // same value, assert true
+        assertTrue(anotherPhone.equals(phoneDescriptor));
+
+        // same object, assert true
+        assertTrue(anotherPhone.equals(anotherPhone));
+
+        // invalid descriptor, check if it is invalid
+        assertEquals(CopyCommandDescriptor.Field.INVALID, invalidDescriptor.getField());
+
+        // different fields, check if both are equal
+        assertNotEquals(invalidDescriptor, phoneDescriptor);
+
+        // different descriptors, check if both are equal
+        assertNotEquals(emailDescriptor, phoneDescriptor);
+    }
+}

--- a/src/test/java/seedu/address/logic/commands/CopyCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/CopyCommandTest.java
@@ -13,6 +13,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static seedu.address.testutil.TypicalStudents.getTypicalAddressBook;
 
 /**
@@ -22,12 +23,10 @@ import static seedu.address.testutil.TypicalStudents.getTypicalAddressBook;
 public class CopyCommandTest {
 
     private Model model;
-    private Model expectedModel;
 
     @BeforeEach
     public void setUp() {
         model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
-        expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
     }
 
     @Test
@@ -43,6 +42,55 @@ public class CopyCommandTest {
             }
         }
         assertEquals(new CopyCommand(copyCommandDescriptor).getCopyContent(model.getFilteredPersonList()),
+                sb.toString());
+    }
+
+    @Test
+    public void execute_validEmailCommand_success() {
+        CopyCommandDescriptor copyCommandDescriptor = new CopyCommandDescriptor("email");
+        List<Person> personList = model.getFilteredPersonList();
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < personList.size(); i++) {
+            if (i == personList.size() - 1) {
+                sb.append(personList.get(i).getEmail());
+            } else {
+                sb.append(personList.get(i).getEmail() + ",");
+            }
+        }
+        assertEquals(new CopyCommand(copyCommandDescriptor).getCopyContent(model.getFilteredPersonList()),
+                sb.toString());
+    }
+
+    @Test
+    public void execute_validNameCommand_success() {
+        CopyCommandDescriptor copyCommandDescriptor = new CopyCommandDescriptor("name");
+        List<Person> personList = model.getFilteredPersonList();
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < personList.size(); i++) {
+            if (i == personList.size() - 1) {
+                sb.append(personList.get(i).getName());
+            } else {
+                sb.append(personList.get(i).getName() + ",");
+            }
+        }
+        assertEquals(new CopyCommand(copyCommandDescriptor).getCopyContent(model.getFilteredPersonList()),
+                sb.toString());
+    }
+
+    @Test
+    public void execute_differentCommand_failure() {
+        // do a sanity check
+        CopyCommandDescriptor copyCommandDescriptor = new CopyCommandDescriptor("phone");
+        List<Person> personList = model.getFilteredPersonList();
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < personList.size(); i++) {
+            if (i == personList.size() - 1) {
+                sb.append(personList.get(i).getEmail());
+            } else {
+                sb.append(personList.get(i).getEmail() + ",");
+            }
+        }
+        assertNotEquals(new CopyCommand(copyCommandDescriptor).getCopyContent(model.getFilteredPersonList()),
                 sb.toString());
     }
 

--- a/src/test/java/seedu/address/logic/commands/CopyCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/CopyCommandTest.java
@@ -1,0 +1,75 @@
+package seedu.address.logic.commands;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import seedu.address.logic.commands.descriptors.CopyCommandDescriptor;
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
+import seedu.address.model.person.NameContainsKeywordsPredicate;
+import seedu.address.model.person.Person;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static seedu.address.testutil.TypicalStudents.getTypicalAddressBook;
+
+/**
+ * Contains integration tests (interaction with the Model) and unit tests for CopyCommand.
+ */
+
+public class CopyCommandTest {
+
+    private Model model;
+    private Model expectedModel;
+
+    @BeforeEach
+    public void setUp() {
+        model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+        expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
+    }
+
+    @Test
+    public void execute_validPhoneCommand_success() {
+        CopyCommandDescriptor copyCommandDescriptor = new CopyCommandDescriptor("phone");
+        List<Person> personList = model.getFilteredPersonList();
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < personList.size(); i++) {
+            if (i == personList.size() - 1) {
+                sb.append(personList.get(i).getPhone());
+            } else {
+                sb.append(personList.get(i).getPhone() + " ");
+            }
+        }
+        assertEquals(new CopyCommand(copyCommandDescriptor).getCopyContent(model.getFilteredPersonList()),
+                sb.toString());
+    }
+
+    @Test
+    public void execute_invalidCommand_failure() {
+        CopyCommandDescriptor copyCommandDescriptor = new CopyCommandDescriptor("fish");
+        assertEquals(new CopyCommand(copyCommandDescriptor).getCopyContent(model.getFilteredPersonList()), "");
+    }
+
+    @Test
+    public void execute_fromFilteredList_success() {
+        CopyCommandDescriptor copyCommandDescriptor = new CopyCommandDescriptor("phone");
+        List<String> keywords = new ArrayList<>();
+        keywords.add("Alice");
+        NameContainsKeywordsPredicate nameContainsKeywordsPredicate = new NameContainsKeywordsPredicate(keywords);
+        model.updateFilteredPersonList(nameContainsKeywordsPredicate);
+        List<Person> personList = model.getFilteredPersonList();
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < personList.size(); i++) {
+            if (i == personList.size() - 1) {
+                sb.append(personList.get(i).getPhone());
+            } else {
+                sb.append(personList.get(i).getPhone() + " ");
+            }
+        }
+        assertEquals(new CopyCommand(copyCommandDescriptor).getCopyContent(model.getFilteredPersonList()),
+                sb.toString());
+    }
+
+}

--- a/src/test/java/seedu/address/logic/commands/CopyCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/CopyCommandTest.java
@@ -1,7 +1,15 @@
 package seedu.address.logic.commands;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static seedu.address.testutil.TypicalStudents.getTypicalAddressBook;
+
+import java.util.ArrayList;
+import java.util.List;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+
 import seedu.address.logic.commands.descriptors.CopyCommandDescriptor;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
@@ -9,12 +17,6 @@ import seedu.address.model.UserPrefs;
 import seedu.address.model.person.NameContainsKeywordsPredicate;
 import seedu.address.model.person.Person;
 
-import java.util.ArrayList;
-import java.util.List;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static seedu.address.testutil.TypicalStudents.getTypicalAddressBook;
 
 /**
  * Contains integration tests (interaction with the Model) and unit tests for CopyCommand.
@@ -70,7 +72,7 @@ public class CopyCommandTest {
             if (i == personList.size() - 1) {
                 sb.append(personList.get(i).getName());
             } else {
-                sb.append(personList.get(i).getName() + ",");
+                sb.append(personList.get(i).getName() + ", ");
             }
         }
         assertEquals(new CopyCommand(copyCommandDescriptor).getCopyContent(model.getFilteredPersonList()),

--- a/src/test/java/seedu/address/logic/commands/EditStudentDescriptorTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditStudentDescriptorTest.java
@@ -17,7 +17,6 @@ import org.junit.jupiter.api.Test;
 import seedu.address.logic.commands.descriptors.EditStudentDescriptor;
 import seedu.address.testutil.EditStudentDescriptorBuilder;
 
-
 public class EditStudentDescriptorTest {
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/CopyCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/CopyCommandParserTest.java
@@ -12,7 +12,6 @@ import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSucces
 
 public class CopyCommandParserTest {
 
-    // for some strange reason, we need the whitespace in front otherwise the parser will not parse correctly
     private static final String EMPTY_FIELD = " " + PREFIX_COPY_FIELD;
 
     private static final String VALID_FIELD_PHONE = " " + PREFIX_COPY_FIELD + "phone";

--- a/src/test/java/seedu/address/logic/parser/CopyCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/CopyCommandParserTest.java
@@ -1,0 +1,53 @@
+package seedu.address.logic.parser;
+
+import org.junit.jupiter.api.Test;
+import seedu.address.logic.commands.CopyCommand;
+import seedu.address.logic.commands.descriptors.CopyCommandDescriptor;
+
+
+import static seedu.address.logic.parser.CliSyntax.PREFIX_COPY_FIELD;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_GENDER;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
+
+public class CopyCommandParserTest {
+
+    // for some strange reason, we need the whitespace in front otherwise the parser will not parse correctly
+    private static final String EMPTY_FIELD = " " + PREFIX_COPY_FIELD;
+
+    private static final String VALID_FIELD_PHONE = " " + PREFIX_COPY_FIELD + "phone";
+    private static final String VALID_FIELD_EMAIL = " " + PREFIX_COPY_FIELD + "email";
+    private static final String VALID_FIELD_WITH_WHITESPACE = " " + PREFIX_COPY_FIELD + "  phone";
+
+    private static final String INVALID_FIELD = " " + PREFIX_COPY_FIELD + "fish";
+    private static final String INVALID_PREFIX = " " + PREFIX_GENDER + "phone";
+
+    private CopyCommandParser parser = new CopyCommandParser();
+
+    @Test
+    public void parse_missingCopyField_failure() {
+        // c/ is present, but has empty argument
+        assertParseFailure(parser, EMPTY_FIELD, CopyCommand.MESSAGE_NOT_VALID_FIELD);
+
+        // c/ is present, but argument is invalid
+        assertParseFailure(parser, INVALID_FIELD, CopyCommand.MESSAGE_NOT_VALID_FIELD);
+    }
+
+    @Test
+    public void parse_missingFields_failure() {
+        // no field specified, c/ prefix mixed up with something else
+        assertParseFailure(parser, INVALID_PREFIX, CopyCommand.NO_FIELD_PROVIDED + "\n" + CopyCommand.MESSAGE_USAGE);
+
+        // no prefix at all
+        assertParseFailure(parser, "", CopyCommand.NO_FIELD_PROVIDED + "\n" + CopyCommand.MESSAGE_USAGE);
+    }
+
+    @Test
+    public void parse_validFields_success() {
+        assertParseSuccess(parser, VALID_FIELD_PHONE, new CopyCommand(new CopyCommandDescriptor("phone")));
+        assertParseSuccess(parser, VALID_FIELD_EMAIL, new CopyCommand(new CopyCommandDescriptor("email")));
+
+        // check whitespace
+        assertParseSuccess(parser, VALID_FIELD_WITH_WHITESPACE, new CopyCommand(new CopyCommandDescriptor("phone")));
+    }
+}

--- a/src/test/java/seedu/address/logic/parser/CopyCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/CopyCommandParserTest.java
@@ -1,14 +1,14 @@
 package seedu.address.logic.parser;
 
-import org.junit.jupiter.api.Test;
-import seedu.address.logic.commands.CopyCommand;
-import seedu.address.logic.commands.descriptors.CopyCommandDescriptor;
-
-
 import static seedu.address.logic.parser.CliSyntax.PREFIX_COPY_FIELD;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_GENDER;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.logic.commands.CopyCommand;
+import seedu.address.logic.commands.descriptors.CopyCommandDescriptor;
 
 public class CopyCommandParserTest {
 


### PR DESCRIPTION
Add copy command

Currently, the syntax is `copy c/[phone/email/name]`. Therefore, only phone, email, or name can be copied. 

While previously we discussed to have `copy phone/email/name` as the official command, this is hard to implement without significant changes to the `argsmultimap` class. Therefore, I've implemented it with the `c/` prefix instead.

