### PR TITLE
Update GUI to fix the following:

### DIFF
--- a/src/main/resources/view/DarkTheme.css
+++ b/src/main/resources/view/DarkTheme.css
@@ -354,7 +354,7 @@
 }
 
 #tags {
-    -fx-hgap: 7;
+    -fx-hgap: 4;
     -fx-vgap: 3;
 }
 
@@ -366,7 +366,9 @@
     -fx-background-radius: 2;
     -fx-font-size: 11;
     -fx-wrap-text: true;
-    -fx-max-width: 85;
+    -fx-pref-width: 40;
+    -fx-pref-width: 80;
+    -fx-alignment: center;
 }
 
 #formClass {

--- a/src/main/resources/view/DarkTheme.css
+++ b/src/main/resources/view/DarkTheme.css
@@ -72,10 +72,6 @@
     -fx-opacity: 1;
 }
 
-.table-view:focused .table-row-cell:filled:focused:selected {
-    -fx-background-color: -fx-focus-color;
-}
-
 .split-pane:horizontal .split-pane-divider {
     -fx-background-color: derive(#1d1d1d, 20%);
     -fx-border-color: transparent transparent transparent #4d4d4d;
@@ -105,22 +101,6 @@
 
 .list-cell:filled:odd {
     -fx-background-color: #515658;
-}
-
-/*.list-cell:filled:selected {*/
-/*    -fx-background-color: #424d5f;*/
-/*}*/
-
-.list-cell:filled:selected #studentCardPane {
-    -fx-background-color: #424d5f;
-    -fx-border-color: #3e7b91;
-    -fx-border-width: 1;
-}
-
-.list-cell:filled:selected #teacherCardPane {
-    -fx-background-color: #424d5f;
-    -fx-border-color: #3e7b91;
-    -fx-border-width: 1;
 }
 
 .list-cell .label {

--- a/src/main/resources/view/MainWindow.fxml
+++ b/src/main/resources/view/MainWindow.fxml
@@ -50,7 +50,7 @@
         </StackPane>
         <SplitPane dividerPositions="0.5" prefHeight="200.0" prefWidth="200.0" VBox.vgrow="ALWAYS">
            <items>
-          <VBox fx:id="studentList" minWidth="480.0" prefWidth="340" styleClass="pane-with-border">
+          <VBox fx:id="studentList" minWidth="500.0" prefWidth="340" styleClass="pane-with-border">
             <padding>
               <Insets bottom="10" left="10" right="10" top="10" />
             </padding>
@@ -65,7 +65,7 @@
                      </HBox>
             <StackPane fx:id="studentListPanelPlaceholder" VBox.vgrow="ALWAYS" />
           </VBox>
-              <VBox fx:id="teacherList" minWidth="480.0" prefWidth="340" styleClass="pane-with-border">
+              <VBox fx:id="teacherList" minWidth="500.0" prefWidth="340" styleClass="pane-with-border">
                  <padding>
                     <Insets bottom="10" left="10" right="10" top="10" />
                  </padding>

--- a/src/main/resources/view/StudentListCard.fxml
+++ b/src/main/resources/view/StudentListCard.fxml
@@ -13,7 +13,7 @@
   <GridPane hgap="3.0" minWidth="450.0" HBox.hgrow="ALWAYS">
     <columnConstraints>
       <ColumnConstraints hgrow="SOMETIMES" minWidth="10.0" percentWidth="60.0" prefWidth="270.0" />
-         <ColumnConstraints hgrow="SOMETIMES" maxWidth="180.0" minWidth="10.0" percentWidth="40.0" prefWidth="180.0" />
+         <ColumnConstraints maxWidth="180.0" minWidth="10.0" percentWidth="40.0" />
     </columnConstraints>
     <VBox alignment="CENTER_LEFT" minHeight="-Infinity" minWidth="200.0" prefWidth="150.0" GridPane.columnIndex="0" GridPane.hgrow="ALWAYS" GridPane.vgrow="ALWAYS">
       <padding>
@@ -25,13 +25,13 @@
       </HBox>
          <HBox prefWidth="150.0">
             <children>
-            <Label fx:id="formClass" styleClass="cell_small_label" text="\$formClass" wrapText="true" />
-            <Label fx:id="involvement" styleClass="cell_small_label" text="\$involvement" wrapText="true">
+            <Label fx:id="formClass" alignment="CENTER" contentDisplay="CENTER" maxWidth="180.0" minWidth="30.0" styleClass="cell_small_label" text="\$formClass" textAlignment="CENTER" wrapText="true" />
+            <Label fx:id="involvement" alignment="CENTER" contentDisplay="CENTER" maxWidth="250.0" minWidth="80.0" styleClass="cell_small_label" text="\$involvement" textAlignment="JUSTIFY" wrapText="true">
                   <HBox.margin>
                      <Insets left="4.0" />
                   </HBox.margin>
                </Label>
-            <Label fx:id="medicalHistory" maxWidth="100.0" styleClass="cell_small_label" text="\$medicalHistory">
+            <Label fx:id="medicalHistory" ellipsisString="!!!" maxWidth="30.0" styleClass="cell_small_label" text="\$medicalHistory">
                   <HBox.margin>
                      <Insets left="4.0" />
                   </HBox.margin>
@@ -44,9 +44,9 @@
       <Label fx:id="gender" styleClass="cell_small_label" text="\$gender" wrapText="true" />
       <Label fx:id="emergencyContact" styleClass="cell_small_label" text="\$emergencyContact" wrapText="true" />
     </VBox>
-      <HBox alignment="TOP_RIGHT" minWidth="175.0" prefWidth="175.0" GridPane.columnIndex="1" GridPane.vgrow="ALWAYS">
+      <HBox alignment="TOP_RIGHT" maxHeight="1.7976931348623157E308" minHeight="-Infinity" minWidth="175.0" prefWidth="175.0" GridPane.columnIndex="1" GridPane.hgrow="NEVER" GridPane.vgrow="ALWAYS">
          <children>
-            <FlowPane fx:id="tags" alignment="TOP_RIGHT" nodeOrientation="LEFT_TO_RIGHT" orientation="VERTICAL" prefWrapLength="180.0">
+            <FlowPane fx:id="tags" alignment="TOP_RIGHT" nodeOrientation="LEFT_TO_RIGHT" prefWrapLength="140.0" HBox.hgrow="SOMETIMES">
                <padding>
                   <Insets bottom="5.0" left="5.0" right="5.0" top="5.0" />
                </padding>
@@ -63,7 +63,7 @@
          </GridPane.margin>
       </HBox>
       <rowConstraints>
-         <RowConstraints />
+         <RowConstraints vgrow="ALWAYS" />
       </rowConstraints>
   </GridPane>
 </HBox>

--- a/src/main/resources/view/StudentListCard.fxml
+++ b/src/main/resources/view/StudentListCard.fxml
@@ -25,13 +25,13 @@
       </HBox>
          <HBox prefWidth="150.0">
             <children>
-            <Label fx:id="formClass" alignment="CENTER" contentDisplay="CENTER" maxWidth="180.0" minWidth="30.0" styleClass="cell_small_label" text="\$formClass" textAlignment="CENTER" wrapText="true" />
-            <Label fx:id="involvement" alignment="CENTER" contentDisplay="CENTER" maxWidth="250.0" minWidth="80.0" styleClass="cell_small_label" text="\$involvement" textAlignment="JUSTIFY" wrapText="true">
+            <Label fx:id="formClass" alignment="CENTER" contentDisplay="CENTER" maxWidth="300.0" minWidth="30.0" styleClass="cell_small_label" text="\$formClass" textAlignment="CENTER" wrapText="true" />
+            <Label fx:id="involvement" alignment="CENTER" contentDisplay="CENTER" maxWidth="300.0" minWidth="80.0" styleClass="cell_small_label" text="\$involvement" textAlignment="JUSTIFY" wrapText="true">
                   <HBox.margin>
                      <Insets left="4.0" />
                   </HBox.margin>
                </Label>
-            <Label fx:id="medicalHistory" ellipsisString="!!!" maxWidth="30.0" styleClass="cell_small_label" text="\$medicalHistory">
+            <Label fx:id="medicalHistory" ellipsisString="!!!" maxWidth="150.0" styleClass="cell_small_label" text="\$medicalHistory">
                   <HBox.margin>
                      <Insets left="4.0" />
                   </HBox.margin>

--- a/src/main/resources/view/TeacherListCard.fxml
+++ b/src/main/resources/view/TeacherListCard.fxml
@@ -13,7 +13,7 @@
     <GridPane hgap="3.0" minWidth="450.0" HBox.hgrow="ALWAYS">
         <columnConstraints>
             <ColumnConstraints hgrow="SOMETIMES" minWidth="10" percentWidth="60.0" prefWidth="270.0" />
-            <ColumnConstraints halignment="LEFT" hgrow="SOMETIMES" minWidth="10.0" percentWidth="40.0" prefWidth="180.0" />
+            <ColumnConstraints maxWidth="180.0" minWidth="10.0" percentWidth="40.0" />
         </columnConstraints>
         <VBox alignment="CENTER_LEFT" minHeight="-Infinity" minWidth="200.0" prefWidth="150.0" GridPane.columnIndex="0">
             <padding>
@@ -36,12 +36,12 @@
             <Label fx:id="gender" styleClass="cell_small_label" text="\$gender" wrapText="true" />
               <Label fx:id="officeTable" styleClass="cell_small_label" text="\$officeTable" wrapText="true" />
         </VBox>
-      <HBox alignment="TOP_RIGHT" minWidth="175.0" prefWidth="175.0" GridPane.columnIndex="1" GridPane.vgrow="ALWAYS">
+      <HBox alignment="TOP_RIGHT" minWidth="175.0" prefWidth="175.0" GridPane.columnIndex="1" GridPane.hgrow="NEVER" GridPane.vgrow="ALWAYS">
          <padding>
             <Insets bottom="2.0" left="2.0" right="2.0" top="2.0" />
          </padding>
          <children>
-                <FlowPane fx:id="tags" alignment="TOP_RIGHT" nodeOrientation="LEFT_TO_RIGHT" orientation="VERTICAL" prefWrapLength="180.0">
+                <FlowPane fx:id="tags" alignment="TOP_RIGHT" nodeOrientation="LEFT_TO_RIGHT" prefWrapLength="140.0" HBox.hgrow="SOMETIMES">
                <padding>
                   <Insets bottom="5.0" left="5.0" right="5.0" top="5.0" />
                </padding>

--- a/src/main/resources/view/TeacherListCard.fxml
+++ b/src/main/resources/view/TeacherListCard.fxml
@@ -25,7 +25,7 @@
             </HBox>
             <HBox prefWidth="150.0">
                 <children>
-                    <Label fx:id="involvement" styleClass="cell_small_label" text="\$involvement" wrapText="true">
+                    <Label fx:id="involvement" alignment="CENTER" contentDisplay="CENTER" minWidth="80.0" styleClass="cell_small_label" text="\$involvement" textAlignment="CENTER" wrapText="true">
                         <HBox.margin>
                             <Insets left="4.0" />
                         </HBox.margin></Label>


### PR DESCRIPTION
Changes include

1. Prevent Tags from spilling over into the other details
2. Change ... in medical window to !!! to inform user that there are medical details for the student
3. Updated Involvement so that it will wrap downwards properly
4. Updated formClass so that it will not stretch along with involvement. 
5. Fix sizing for the MainWindow.fxml so that even at the smallest screen, the horizontal scroll bar will not be needed / will not show @nniiggeell Do check if this is ok 
6. Update sizing for Involvement, Class, Medical so that not one control the rest
7. Remove selected blue frame as it cannot be unselected (cannot fix this so just remove that feature)

Sample:

Tags when screen is small and screen is big (No more spilling over)
![image](https://user-images.githubusercontent.com/80570422/139713144-08ba8c9a-03eb-45f5-b865-33c2a0496174.png)

Form Class and Involvement are long but don't kill each other
![image](https://user-images.githubusercontent.com/80570422/139713310-39a3c198-0e22-48c2-8cde-bda867329e24.png)

Form class does not get stretched like before when involvement is very long
![image](https://user-images.githubusercontent.com/80570422/139713401-2437649b-ab06-4ed4-9afb-c8d6fe7c18ee.png)

Medical Shows !!! if there is more lines after it
![image](https://user-images.githubusercontent.com/80570422/139713602-b741d35a-2798-496a-b19f-43dc0281172c.png)
![image](https://user-images.githubusercontent.com/80570422/139713637-10d7608c-4e74-4b2a-99cf-affee88526f3.png)

This is how "well" the GUI will be if its super abused when its long (left) and small (right)
![image](https://user-images.githubusercontent.com/80570422/139716851-ee486e53-93af-4a9c-9900-0a0df69f6e7e.png)



@g4ryy u can just approve even if nigel haven checked yet cause that one is quite easy to change

Closes and fixes:
#208
#215

